### PR TITLE
fixed packages to make vscode understand networkbehaviours correctly

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ide.rider": "1.1.4",
-    "com.unity.ide.vscode": "1.1.4",
+    "com.unity.ide.vscode": "1.1.3",
     "com.unity.multiplayer-hlapi": "1.0.4",
     "com.unity.test-framework": "1.1.9",
     "com.unity.textmeshpro": "2.0.1",


### PR DESCRIPTION
So basically, the reason vscode doesn't like any of the NetworkBehaviour classes/methods/etc is because the newest version of the unity package that integrates it with vscode broke that. I rolled it back to the previous version, so vscode won't complain that NetworkBehaviour doesn't exist