### PR TITLE
Fix/weapon tile display

### DIFF
--- a/Assets/Animations/Weapon 0.anim
+++ b/Assets/Animations/Weapon 0.anim
@@ -20,10 +20,10 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 6919366548538155999, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
+      value: {fileID: -287763524560535101, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
         type: 3}
     - time: 0.016666668
-      value: {fileID: -287763524560535101, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
+      value: {fileID: 6919366548538155999, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
         type: 3}
     attribute: m_Sprite
     path: 
@@ -44,8 +44,8 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 6919366548538155999, guid: 72add087aa6c76c6fbe7c60a3bedd3d3, type: 3}
     - {fileID: -287763524560535101, guid: 72add087aa6c76c6fbe7c60a3bedd3d3, type: 3}
+    - {fileID: 6919366548538155999, guid: 72add087aa6c76c6fbe7c60a3bedd3d3, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Animations/Weapon 1.anim
+++ b/Assets/Animations/Weapon 1.anim
@@ -20,10 +20,10 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: -6815691675891187282, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
+      value: {fileID: -5488275578273347653, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
         type: 3}
     - time: 0.016666668
-      value: {fileID: -5488275578273347653, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
+      value: {fileID: -6815691675891187282, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
         type: 3}
     attribute: m_Sprite
     path: 
@@ -44,8 +44,8 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: -6815691675891187282, guid: 72add087aa6c76c6fbe7c60a3bedd3d3, type: 3}
     - {fileID: -5488275578273347653, guid: 72add087aa6c76c6fbe7c60a3bedd3d3, type: 3}
+    - {fileID: -6815691675891187282, guid: 72add087aa6c76c6fbe7c60a3bedd3d3, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Animations/Weapon Drop.anim
+++ b/Assets/Animations/Weapon Drop.anim
@@ -20,10 +20,10 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 1518363075290452430, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
+      value: {fileID: -6523628323415844430, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
         type: 3}
     - time: 0.016666668
-      value: {fileID: -6523628323415844430, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
+      value: {fileID: 1518363075290452430, guid: 72add087aa6c76c6fbe7c60a3bedd3d3,
         type: 3}
     attribute: m_Sprite
     path: 
@@ -44,8 +44,8 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 1518363075290452430, guid: 72add087aa6c76c6fbe7c60a3bedd3d3, type: 3}
     - {fileID: -6523628323415844430, guid: 72add087aa6c76c6fbe7c60a3bedd3d3, type: 3}
+    - {fileID: 1518363075290452430, guid: 72add087aa6c76c6fbe7c60a3bedd3d3, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Scripts/NetworkScripts/Cell.cs
+++ b/Assets/Scripts/NetworkScripts/Cell.cs
@@ -83,6 +83,6 @@ public struct Cell {
     }
 
     public void PickRandWeapon() {
-        weapon = new System.Random().Next(NUM_WEAPONS);
+        weapon = Util.random.Next(NUM_WEAPONS);
     }
 }

--- a/Assets/Scripts/NetworkScripts/GameState.cs
+++ b/Assets/Scripts/NetworkScripts/GameState.cs
@@ -680,6 +680,7 @@ public class GameState : NetworkBehaviour
                     playerData.Add(newPlayer);
                     SpawnPlayer(id);
                     id.GetComponent<PlayerConnectionComponent>().RpcSetPlayerColor(newPlayer.color);
+                    id.GetComponent<PlayerConnectionComponent>().RpcSetAtkIndicatorWeapon(newPlayer.weapon, 0, newPlayer.lastMoveDirection);
                 }
 
                 MusicManager m = MusicManager.musicManager;

--- a/Assets/Scripts/NetworkScripts/PlayerData.cs
+++ b/Assets/Scripts/NetworkScripts/PlayerData.cs
@@ -25,7 +25,8 @@ public struct PlayerData {
         this.length = START_LENGTH;
         this.spawned = false;
         this.atkCharge = 0;
-        this.weapon = 0;
+        this.weapon = Util.random.Next(Cell.NUM_WEAPONS);
+        Debug.Log(this.weapon);
         this.lastMoveDirection = Vector2.zero;
         this.beatsToRespawn = 0;
         this.movedThisTurn = false;

--- a/Assets/Scripts/Util.cs
+++ b/Assets/Scripts/Util.cs
@@ -5,4 +5,6 @@ public class Util {
     {
         return a - b * (float) Math.Floor(a / b);
     }
+
+    public static Random random = new Random();
 }


### PR DESCRIPTION
Weapon tiles now display a better sprite, though animation is still broken.
Fixed bug where, because all weapon drops were picking first weapon at same time, each with their own new Random created at that time, all the first drops were the same.
Player weapon is now randomly assigned at creation.